### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -58,7 +58,7 @@ jobs:
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.0
+        uses: docker/setup-buildx-action@v3.7.1
         with:
           buildkitd-config: .github/buildkitd.toml
           driver-opts: |

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -58,7 +58,7 @@ jobs:
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.0
+        uses: docker/setup-buildx-action@v3.7.1
         with:
           buildkitd-config: .github/buildkitd.toml
           driver-opts: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.7.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.7.1)** on 2024-10-04T07:44:26Z
