### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -84,7 +84,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5.6.0
         with:
           images: |
             name=snowdreamtech/rust,enable=true

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -84,7 +84,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5.6.0
         with:
           images: |
             name=snowdreamtech/rust,enable=true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.6.0](https://github.com/docker/metadata-action/releases/tag/v5.6.0)** on 2024-11-19T14:58:42Z
